### PR TITLE
chore: update experience data

### DIFF
--- a/src/lib/experience-data.json
+++ b/src/lib/experience-data.json
@@ -2,7 +2,7 @@
   {
     "id": 1,
     "role": "Software Engineer Intern",
-    "company": "26ideas",
+    "company": "26ideas (Venture Studio)",
     "period": "Apr 2024 - Aug 2024",
     "description": "26ideas is a full-stack venture studio that builds, incubates, and invests in early-stage startups. Built foundational components of CRM tools, including roles management, product categories, subcategories, users, projects, and task management.",
     "tags": [
@@ -19,7 +19,7 @@
   {
     "id": 2,
     "role": "Software Engineer",
-    "company": "26ideas",
+    "company": "26ideas (Venture Studio)",
     "period": "Aug 2024 - Apr 2025",
     "description": "Developed an internal business CRM (crm.26ideas.com) from scratch using Next.js, NestJS, Prisma, PostgreSQL, and OpenAI for AI utilities.",
     "tags": ["Product", "Engineering", "Development"]
@@ -35,9 +35,17 @@
   {
     "id": 4,
     "role": "Software Engineer",
-    "company": "Strique AI",
+    "company": "Strique (Marketing OS)",
     "period": "June 2025 - Present",
-    "description": "Monitor campaigns, manage catalog, and automate reporting—all from one dashboard developed exclusively for e-commerce brands and agencies focused on ROAS.",
-    "tags": ["Product", "Java", "Spring Boot", "Protobuf", "Nextjs"]
+    "description": "Developed full-stack AI-powered Marketing OS features using Next.js, Python, and PostgreSQL. Architected multi-agent AI workflows and MCP connector system for third-party integrations (GA4, Google Search Console, TikTok, Mailchimp). Designed PostgreSQL schemas for conversation persistence, integrated PostHog analytics, and enabled scalable data access with intelligent query routing and marketing automation.",
+    "tags": [
+      "Product",
+      "Java",
+      "Spring Boot",
+      "Protobuf",
+      "Nextjs",
+      "openai-sdk",
+      "PostHog"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- clarify 26ideas company label as Venture Studio
- update Strique role/company label and expand Marketing OS experience details
- add OpenAI SDK and PostHog tags to current experience

## Validation
- npm run build